### PR TITLE
Unpushed commits (local main ahead of origin/main)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Rhys Lees",
-            "email": "43909932+RhysLees@users.noreply.github.com",
-            "role": "Developer"
+            "name": "Sebastian Bürgin-Fix",
+            "email": "helpdesk@codebar.ch",
+            "homepage": "https://www.codebar.ch",
+            "role": "Software-Engineer"
         }
     ],
     "require": {


### PR DESCRIPTION
Local main was 2 commit(s) ahead of origin/main. Opened from update-opensource-active.sh for review.